### PR TITLE
Bump version: dbt-antlr4 2.0.0 (runtime and tool)

### DIFF
--- a/antlr4-maven-plugin/pom.xml
+++ b/antlr4-maven-plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.antlr</groupId>
     <artifactId>antlr4-master</artifactId>
-    <version>4.13.3-DBT135</version>
+    <version>2.0.0</version>
   </parent>
   <artifactId>antlr4-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	</parent>
 	<groupId>org.antlr</groupId>
 	<artifactId>antlr4-master</artifactId>
-	<version>4.13.3-DBT135</version>
+	<version>2.0.0</version>
 	<packaging>pom</packaging>
 
 	<name>ANTLR 4</name>

--- a/runtime-testsuite/pom.xml
+++ b/runtime-testsuite/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.antlr</groupId>
 		<artifactId>antlr4-master</artifactId>
-		<version>4.13.3-DBT135</version>
+		<version>2.0.0</version>
 	</parent>
 	<artifactId>antlr4-runtime-testsuite</artifactId>
 	<name>ANTLR 4 Runtime Tests (4th generation)</name>

--- a/runtime/Java/pom.xml
+++ b/runtime/Java/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.antlr</groupId>
 		<artifactId>antlr4-master</artifactId>
-		<version>4.13.3-DBT135</version>
+		<version>2.0.0</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<artifactId>antlr4-runtime</artifactId>

--- a/runtime/Rust/Cargo.lock
+++ b/runtime/Rust/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "dbt-antlr4"
-version = "1.3.6"
+version = "2.0.0"
 dependencies = [
  "bit-set",
  "bumpalo",

--- a/runtime/Rust/Cargo.toml
+++ b/runtime/Rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbt-antlr4"
-version = "1.3.6"
+version = "2.0.0"
 authors = ["Konstantin Anisimov <rrevenantt@gmail.com>", "Alex Snaps <alex@wcgw.dev>", "Bo Lin <bo@dreamsphere.org>"]
 homepage = "https://github.com/sdf-labs/antlr4"
 repository = "https://github.com/sdf-labs/antlr4"

--- a/runtime/Rust/README.md
+++ b/runtime/Rust/README.md
@@ -1,6 +1,6 @@
 # dbt-antlr4
-[![Crate](https://flat.badgen.net/crates/v/dbt-antlr4)](https://crates.io/crates/dbt-antlr4/1.0.0)
-[![docs](https://flat.badgen.net/badge/docs.rs/v1.0.0)](https://docs.rs/dbt-antlr4/1.0.0)
+[![Crate](https://flat.badgen.net/crates/v/dbt-antlr4)](https://crates.io/crates/dbt-antlr4/2.0.0)
+[![docs](https://flat.badgen.net/badge/docs.rs/v2.0.0)](https://docs.rs/dbt-antlr4/2.0.0)
 
 
 > **NOTE**:
@@ -35,7 +35,7 @@ Then add following to `Cargo.toml` of the crate from which generated parser
 is going to be used:
 ```toml 
 [dependencies]
-dbt-antlr4 = "1.0.0"
+dbt-antlr4 = "2.0.0"
 ```
   
 

--- a/runtime/Rust/gen_test_grammars.sh
+++ b/runtime/Rust/gen_test_grammars.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TOOL_VERSION="4.13.3-DBT135"
-ANTLR_PATH="../../../tool/target/antlr4-${TOOL_VERSION}-complete.jar"
+TOOL_VERSION="2.0.0"
+ANTLR_PATH="../../../tool/target/dbt-antlr4-${TOOL_VERSION}-complete.jar"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 declare -a GRAMMARS=(

--- a/runtime/Rust/tests/gen/csvlexer.rs
+++ b/runtime/Rust/tests/gen/csvlexer.rs
@@ -25,7 +25,7 @@ use dbt_antlr4::vocabulary::{Vocabulary,VocabularyImpl};
 use std::ops::{DerefMut, Deref};
 use std::sync::LazyLock;
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const T__0:i32=1; 
 pub const T__1:i32=2; 
 pub const T__2:i32=3; 

--- a/runtime/Rust/tests/gen/csvparser.rs
+++ b/runtime/Rust/tests/gen/csvparser.rs
@@ -36,7 +36,7 @@ use std::sync::LazyLock;
 use std::rc::Rc;
 use std::ops::{DerefMut, Deref};
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const CSV_T__0:i32=1; 
 pub const CSV_T__1:i32=2; 
 pub const CSV_T__2:i32=3; 

--- a/runtime/Rust/tests/gen/labelslexer.rs
+++ b/runtime/Rust/tests/gen/labelslexer.rs
@@ -25,7 +25,7 @@ use dbt_antlr4::vocabulary::{Vocabulary,VocabularyImpl};
 use std::ops::{DerefMut, Deref};
 use std::sync::LazyLock;
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const T__0:i32=1; 
 pub const T__1:i32=2; 
 pub const T__2:i32=3; 

--- a/runtime/Rust/tests/gen/labelsparser.rs
+++ b/runtime/Rust/tests/gen/labelsparser.rs
@@ -34,7 +34,7 @@ use std::sync::LazyLock;
 use std::rc::Rc;
 use std::ops::{DerefMut, Deref};
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const Labels_T__0:i32=1; 
 pub const Labels_T__1:i32=2; 
 pub const Labels_T__2:i32=3; 

--- a/runtime/Rust/tests/gen/referencetoatnlexer.rs
+++ b/runtime/Rust/tests/gen/referencetoatnlexer.rs
@@ -25,7 +25,7 @@ use dbt_antlr4::vocabulary::{Vocabulary,VocabularyImpl};
 use std::ops::{DerefMut, Deref};
 use std::sync::LazyLock;
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const ID:i32=1; 
 pub const ATN:i32=2; 
 pub const WS:i32=3;

--- a/runtime/Rust/tests/gen/referencetoatnparser.rs
+++ b/runtime/Rust/tests/gen/referencetoatnparser.rs
@@ -34,7 +34,7 @@ use std::sync::LazyLock;
 use std::rc::Rc;
 use std::ops::{DerefMut, Deref};
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const ReferenceToATN_ID:i32=1; 
 pub const ReferenceToATN_ATN:i32=2; 
 pub const ReferenceToATN_WS:i32=3;

--- a/runtime/Rust/tests/gen/simplelrlexer.rs
+++ b/runtime/Rust/tests/gen/simplelrlexer.rs
@@ -25,7 +25,7 @@ use dbt_antlr4::vocabulary::{Vocabulary,VocabularyImpl};
 use std::ops::{DerefMut, Deref};
 use std::sync::LazyLock;
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const ID:i32=1; 
 pub const WS:i32=2;
 

--- a/runtime/Rust/tests/gen/simplelrparser.rs
+++ b/runtime/Rust/tests/gen/simplelrparser.rs
@@ -34,7 +34,7 @@ use std::sync::LazyLock;
 use std::rc::Rc;
 use std::ops::{DerefMut, Deref};
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const SimpleLR_ID:i32=1; 
 pub const SimpleLR_WS:i32=2;
 pub const SimpleLR_EOF:i32=EOF;

--- a/runtime/Rust/tests/gen/visitorbasiclexer.rs
+++ b/runtime/Rust/tests/gen/visitorbasiclexer.rs
@@ -25,7 +25,7 @@ use dbt_antlr4::vocabulary::{Vocabulary,VocabularyImpl};
 use std::ops::{DerefMut, Deref};
 use std::sync::LazyLock;
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const A:i32=1;
 
 pub const channelNames: [&'static str;0+2] = [

--- a/runtime/Rust/tests/gen/visitorbasicparser.rs
+++ b/runtime/Rust/tests/gen/visitorbasicparser.rs
@@ -36,7 +36,7 @@ use std::sync::LazyLock;
 use std::rc::Rc;
 use std::ops::{DerefMut, Deref};
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const VisitorBasic_A:i32=1;
 pub const VisitorBasic_EOF:i32=EOF;
 pub const RULE_s:usize = 0;

--- a/runtime/Rust/tests/gen/visitorcalclexer.rs
+++ b/runtime/Rust/tests/gen/visitorcalclexer.rs
@@ -25,7 +25,7 @@ use dbt_antlr4::vocabulary::{Vocabulary,VocabularyImpl};
 use std::ops::{DerefMut, Deref};
 use std::sync::LazyLock;
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const INT:i32=1; 
 pub const MUL:i32=2; 
 pub const DIV:i32=3; 

--- a/runtime/Rust/tests/gen/visitorcalcparser.rs
+++ b/runtime/Rust/tests/gen/visitorcalcparser.rs
@@ -36,7 +36,7 @@ use std::sync::LazyLock;
 use std::rc::Rc;
 use std::ops::{DerefMut, Deref};
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const VisitorCalc_INT:i32=1; 
 pub const VisitorCalc_MUL:i32=2; 
 pub const VisitorCalc_DIV:i32=3; 

--- a/runtime/Rust/tests/gen/xmllexer.rs
+++ b/runtime/Rust/tests/gen/xmllexer.rs
@@ -25,7 +25,7 @@ use dbt_antlr4::vocabulary::{Vocabulary,VocabularyImpl};
 use std::ops::{DerefMut, Deref};
 use std::sync::LazyLock;
 
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 pub const COMMENT:i32=1; 
 pub const CDATA:i32=2; 
 pub const DTD:i32=3; 

--- a/tool-testsuite/pom.xml
+++ b/tool-testsuite/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.antlr</groupId>
     <artifactId>antlr4-master</artifactId>
-    <version>4.13.3-DBT135</version>
+    <version>2.0.0</version>
   </parent>
   <artifactId>antlr4-tool-testsuite</artifactId>
   <name>ANTLR 4 Tool Tests</name>

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.antlr</groupId>
 		<artifactId>antlr4-master</artifactId>
-		<version>4.13.3-DBT135</version>
+		<version>2.0.0</version>
 	</parent>
 	<artifactId>antlr4</artifactId>
 	<name>ANTLR 4 Tool</name>
@@ -114,6 +114,7 @@
 							<minimizeJar>false</minimizeJar>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
+							<shadedArtifactId>dbt-antlr4</shadedArtifactId>
 							<shadedClassifierName>complete</shadedClassifierName>
 							<artifactSet>
 								<excludes>

--- a/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
+++ b/tool/resources/org/antlr/v4/tool/templates/codegen/Rust/Rust.stg
@@ -249,7 +249,7 @@ fileHeader(grammarFileName, ANTLRVersion) ::= <<
 >>
 
 Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 <if(parser.tokens)>
 <parser.tokens:{k | pub const <parser.grammarName>_<k>:i32=<parser.tokens.(k)>;}; separator=" \n">
 <endif>
@@ -1269,7 +1269,7 @@ use std::sync::LazyLock;
 >>
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
-dbt_antlr4::check_version!("1","3");
+dbt_antlr4::check_version!("2","0");
 <if(lexer.tokens)>
 <lexer.tokens:{k | pub const <k>:i32=<lexer.tokens.(k)>}; separator="; \n", wrap, anchor>;
 <endif>


### PR DESCRIPTION
Unify the fork's versioning as dbt-antlr4 2.0.0:
- Maven modules: 4.13.3-DBT135 -> 2.0.0; the shaded tool jar is now named dbt-antlr4-2.0.0-complete.jar (shadedArtifactId; the Maven coordinate remains org.antlr:antlr4)
- Rust runtime crate: 1.3.6 -> 2.0.0; check_version! handshake bumped to ("2","0") in Rust.stg and regenerated test parsers
- gen_test_grammars.sh updated for the new jar name/version

<!--
Thank you for proposing a contribution to the ANTLR project!

(Please make sure your PR is in a branch other than dev or master
 and also make sure that you derive this branch from dev.)

As of 4.10, ANTLR uses the Linux Foundation's Developer
Certificate of Origin, DCO, version 1.1. See either
https://developercertificate.org/ or file 
contributors-cert-of-origin.txt in the main directory.

Each commit requires a "signature", which is simple as
using `-s` (not `-S`) to the git commit command: 

git commit -s -m 'This is my commit message'

Github's pull request process enforces the sig and gives
instructions on how to fix any commits that lack the sig.
See https://github.com/apps/dco for more info.

No signature is required in this file (unlike the
previous ANTLR contributor's certificate of origin.)
-->
